### PR TITLE
修改pushNamed<String>泛型参数为dynamic，解决点击报错: "type 'MaterialPageRoute<dyna…

### DIFF
--- a/flutter_navigator/lib/main.dart
+++ b/flutter_navigator/lib/main.dart
@@ -46,8 +46,8 @@ class _MyHomePageState extends State<MyHomePage> {
           children: <Widget>[
 
             new FlatButton(onPressed: (){
-              
-              Navigator.pushNamed<String>(context, "nameRoute");
+
+              Navigator.pushNamed<dynamic>(context, "nameRoute");
 
             }, child: new Text("直接使用name跳转")),
 


### PR DESCRIPTION
在点击例子中的第一个按钮「直接使用name跳转」时，出现了错误：```type 'MaterialPageRoute<dynamic>' is not a subtype of type 'Route<String>’```，经过修改、测试已经可以成功跳转。

环境：
>Flutter 0.7.3 • channel beta • https://github.com/flutter/flutter.git
Framework • revision 3b309bda07 (5 weeks ago) • 2018-08-28 12:39:24 -0700
Engine • revision af42b6dc95
Tools • Dart 2.1.0-dev.1.0.flutter-ccb16f7282

